### PR TITLE
fix: replace Bitnami images with open Soldevelo equivalents

### DIFF
--- a/stack/docker-compose.yml
+++ b/stack/docker-compose.yml
@@ -108,7 +108,7 @@ services:
       - "9001:9001"
 
   postgres-primary:
-    image: bitnami/postgresql-repmgr:16
+    image: soldevelo/postgresql-repmgr:16
     container_name: postgres-primary
     restart: always
     environment:
@@ -128,7 +128,7 @@ services:
       - "5432:5432"
 
   postgres-replica:
-    image: bitnami/postgresql-repmgr:16
+    image: soldevelo/postgresql-repmgr:16
     container_name: postgres-replica
     restart: always
     environment:


### PR DESCRIPTION
## Fix: replace restricted Bitnami images

Since **August 28, 2025**, Bitnami distributes most container images only through paid VMware Tanzu subscriptions. Pulling them without a valid subscription may fail silently or return stale image layers, which is a supply-chain reliability concern.

This PR replaces every affected reference with the corresponding image from [SolDevelo/containers](https://github.com/SolDevelo/containers) - a community fork of `bitnami/containers` that publishes identical, freely accessible images to Docker Hub under the `soldevelo/` namespace.

No configuration changes beyond the image tag itself are required.

## Replaced references

- `bitnami/postgresql-repmgr:16` → [`soldevelo/postgresql-repmgr:16`](https://hub.docker.com/r/soldevelo/postgresql-repmgr)